### PR TITLE
Disable Progress bar via progressPreference 

### DIFF
--- a/GrabVideo.ps1
+++ b/GrabVideo.ps1
@@ -13,6 +13,9 @@ $filename = 'ProtectVideo.mp4'
 $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
 [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
 
+$oldProgressPreference = $progressPreference;
+$progressPreference = 'SilentlyContinue';
+
 $loginURI = "$baseURI/auth"
 $authUri = "$baseURI/auth/access-key"
 $EpocStart = Get-Date -Date "01/01/1970"
@@ -186,3 +189,5 @@ Invoke-WebRequest -Uri $exportVideoString -Method Get  -ContentType "application
 
 
 Write-host 'your file was saved to ' $savepath
+
+$progressPreference = $oldProgressPreference


### PR DESCRIPTION
Using progressPreference to disable the progress bar decreased the export time for a 1hr export from 5min down to 40 seconds.